### PR TITLE
Added correct comment syntax to language-configuration.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,8 @@ All notable changes to the "hoon" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.1.1
+- Fixed comment syntax in language-configuration
+
 ## [Unreleased]
 - Initial release

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "::"
     },
     // symbols used as brackets
     "brackets": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "hoon",
     "displayName": "Hoon",
     "description": "Language support for the Hoon language",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "urbit",
     "repository": "https://github.com/famousj/hoon-vscode.git",
     "icon": "images/urbit.png",


### PR DESCRIPTION
I found that the extension will display comments in the correct color, but using the keyboard shortcut to comment out a line inserts a javascript-style `//`, as `language-configuration.json` wasn't changed from its defaults.

This pull request fixes it.